### PR TITLE
Build fix (skips 64-bit flavors)

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -5,7 +5,7 @@ buildscript {
         jcenter()
     }
     dependencies {
-        classpath 'com.android.tools.build:gradle-experimental:0.2.1'
+        classpath 'com.android.tools.build:gradle-experimental:0.3.0-alpha7'
 
         // NOTE: Do not place your application dependencies here; they belong
         // in the individual module build.gradle files

--- a/demo/build.gradle
+++ b/demo/build.gradle
@@ -12,11 +12,11 @@ model {
             versionCode = 1
             versionName = "1.0"
         }
-    }
 
-    compileOptions.with {
-        sourceCompatibility=JavaVersion.VERSION_1_7
-        targetCompatibility=JavaVersion.VERSION_1_7
+        compileOptions.with {
+            sourceCompatibility=JavaVersion.VERSION_1_7
+            targetCompatibility=JavaVersion.VERSION_1_7
+        }
     }
 
     android.buildTypes {

--- a/demo/src/main/AndroidManifest.xml
+++ b/demo/src/main/AndroidManifest.xml
@@ -1,6 +1,6 @@
 <?xml version="1.0" encoding="utf-8"?>
 <manifest xmlns:android="http://schemas.android.com/apk/res/android"
-    package="me.courbiere.rtspextractor" >
+    package="me.courbiere.rtspextractor.demo" >
 
     <application
         android:allowBackup="true"
@@ -9,7 +9,7 @@
         android:supportsRtl="true"
         android:theme="@style/AppTheme" >
         <activity
-            android:name=".demo.MainActivity"
+            android:name=".MainActivity"
             android:label="@string/title_activity_main"
             android:theme="@style/AppTheme.NoActionBar" >
             <intent-filter>

--- a/demo/src/main/java/me/courbiere/rtspextractor/demo/MainActivity.java
+++ b/demo/src/main/java/me/courbiere/rtspextractor/demo/MainActivity.java
@@ -7,7 +7,7 @@ import android.support.v7.app.AppCompatActivity;
 import android.support.v7.widget.Toolbar;
 import android.view.View;
 
-import me.courbiere.rtspextractor.R;
+import me.courbiere.rtspextractor.demo.R;
 
 public class MainActivity extends AppCompatActivity {
 

--- a/gradle/wrapper/gradle-wrapper.properties
+++ b/gradle/wrapper/gradle-wrapper.properties
@@ -3,4 +3,4 @@ distributionBase=GRADLE_USER_HOME
 distributionPath=wrapper/dists
 zipStoreBase=GRADLE_USER_HOME
 zipStorePath=wrapper/dists
-distributionUrl=https\://services.gradle.org/distributions/gradle-2.5-all.zip
+distributionUrl=https\://services.gradle.org/distributions/gradle-2.6-all.zip

--- a/library/build.gradle
+++ b/library/build.gradle
@@ -3,20 +3,19 @@ apply plugin: 'com.android.model.library'
 model {
     android {
         compileSdkVersion = 23
-        buildToolsVersion = "23.0.1"
+        buildToolsVersion = "23.0.2"
 
         defaultConfig.with {
-            applicationId = "me.courbiere.rtspextractor"
             minSdkVersion.apiLevel = 16
             targetSdkVersion.apiLevel = 23
             versionCode = 1
             versionName = "1.0"
         }
-    }
 
-    compileOptions.with {
-        sourceCompatibility=JavaVersion.VERSION_1_7
-        targetCompatibility=JavaVersion.VERSION_1_7
+        compileOptions.with {
+            sourceCompatibility=JavaVersion.VERSION_1_7
+            targetCompatibility=JavaVersion.VERSION_1_7
+        }
     }
 
     /*
@@ -26,20 +25,20 @@ model {
         moduleName = "rtspextractor"
         toolchain = "clang"
         toolchainVersion = "3.5"
-//        cppFlags  += "-march=armv7-a"
-        cppFlags  += "-mfloat-abi=softfp"
-        cppFlags  += "-mfpu=neon"
-        cppFlags  += "-g"
-        cppFlags  += "-O0"
-        cppFlags  += "-I${file("src/main/jni/include")}".toString()
-        ldFlags   += "-L${file("src/main/jniLibs/")}".toString()
-        ldLibs    += ["log", "z", "m", "avformat-56", "avcodec-56", "swscale-3", "avutil-54", "ssl", "rtmp-1"]
+//        cppFlags.add("-march=armv7-a")
+        cppFlags.add("-mfloat-abi=softfp")
+        cppFlags.add("-mfpu=neon")
+        cppFlags.add("-g")
+        cppFlags.add("-O0")
+        cppFlags.add("-I${file("src/main/jni/include")}".toString())
+        ldFlags.add("-L${file("src/main/jniLibs/")}".toString())
+        ldLibs.addAll(["log", "z", "m", "avformat-56", "avcodec-56", "swscale-3", "avutil-54", "ssl", "rtmp-1"])
     }
 
     android.buildTypes {
         release {
             minifyEnabled = false
-            proguardFiles += file('proguard-rules.pro')
+            proguardFiles.add(file('proguard-rules.pro'))
         }
     }
 
@@ -47,28 +46,38 @@ model {
         // for detailed abiFilter descriptions, refer to "Supported ABIs" @
         // https://developer.android.com/ndk/guides/abis.html#sa
         create("arm") {
-            ndk.abiFilters += "armeabi"
+            ndk.with {
+                abiFilters.add("armeabi")
+                abiFilters.add("armeabi-v7a")
+            }
         }
-        create("arm7") {
-            ndk.abiFilters += "armeabi-v7a"
-        }
-        create("arm8") {
-            ndk.abiFilters += "arm64-v8a"
-        }
+//        create("arm8") {
+//            ndk.with {
+//                abiFilters.add("arm64-v8a")
+//            }
+//        }
         create("x86") {
-            ndk.abiFilters += "x86"
+            ndk.with {
+                abiFilters.add("x86")
+            }
         }
-        create("x86-64") {
-            ndk.abiFilters += "x86_64"
-        }
+//        create("x86-64") {
+//            ndk.with {
+//                abiFilters.add("x86_64")
+//            }
+//        }
         create("mips") {
-            ndk.abiFilters += "mips"
+            ndk.with {
+                abiFilters.add("mips")
+            }
         }
-        create("mips-64") {
-            ndk.abiFilters += "mips64"
-        }
+//        create("mips-64") {
+//            ndk.with {
+//                abiFilters.add("mips64")
+//            }
+//        }
         // To include all cpu architectures, leaves abiFilters empty
-        create("all")
+//        create("all")
     }
 }
 


### PR DESCRIPTION
Hi Arnauld,

I managed to get the project to build by skipping the building of the 64-bit flavors, plus other tweaks. I don't yet know how to make 64-bit versions of the ffmpeg .so files, so perhaps you can do that (and update the repo)?

Here are the major changes:
- Commented out 64-bit favors (we need to provide 64-bit versions of the ffmpeg .so files before we can uncomment out the 64-bit favors).
- Commented out the `all` favor (if we want to use `all`, then we don't need any of the individual favors, but we would still need 64-bit versions of the ffmpeg .so files).
- Modified to conform better to http://tools.android.com/tech-docs/new-build-system/gradle-experimental.
- Updated some dependencies.
